### PR TITLE
Fixing exceptions in server on client connect

### DIFF
--- a/syng/server.py
+++ b/syng/server.py
@@ -901,7 +901,8 @@ class Server:
                 ),
             )
 
-            await self.sio.enter_room(sid, room)
+            
+            self.sio.enter_room(sid, room)
             await self.sio.emit("client-registered", {"success": True, "room": room}, room=sid)
             await self.send_state(self.clients[room], sid)
 
@@ -1000,7 +1001,7 @@ class Server:
         if data["room"] in self.clients:
             async with self.sio.session(sid) as session:
                 session["room"] = data["room"]
-                await self.sio.enter_room(sid, session["room"])
+                self.sio.enter_room(sid, session["room"])
             state = self.clients[session["room"]]
             await self.send_state(state, sid)
             return True


### PR DESCRIPTION
(When installed through a PKGBUILD in arch linux and using a local server:)
* When connecting in 2.1.0 with a terminal client the server creates an exception and the client cannot successfully connect
* The traceback of the exception is: TypeError: object NoneType can't be used in 'await' expression
* Traceback origin is File "/usr/lib/python3.13/site-packages/syng/server.py", line 833, in handle_register_client await self.sio.enter_room(sid, room)
* Removing the await statements fixes the issue and the terminal client can connect successfully

Can you reproduce the error in 2.1.0?
Is it solved when you backport this change together with 25cf5468434ff53894aa95441011854011766f08 and 91dec5bcd9acb3360ff0fb1506867895c80e1731?

**edit**: or even without backporting.