### PR TITLE
feat: added hover help texts on labels

### DIFF
--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -547,6 +547,7 @@ class RowWidget[T](QWidget):
         self.description = description
         self._label = QLabel(description, self)
         self._label.setToolTip(help)
+        self._label.setCursor(Qt.WhatsThisCursor)
         self.valueChanged.connect(self._set_internal_value)
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -546,6 +546,7 @@ class RowWidget[T](QWidget):
         self.help = help
         self.description = description
         self._label = QLabel(description, self)
+        self._label.setToolTip(help)
         self.valueChanged.connect(self._set_internal_value)
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -547,7 +547,7 @@ class RowWidget[T](QWidget):
         self.description = description
         self._label = QLabel(description, self)
         self._label.setToolTip(help)
-        self._label.setCursor(Qt.WhatsThisCursor)
+        self._label.setCursor(Qt.CursorShape.WhatsThisCursor)
         self.valueChanged.connect(self._set_internal_value)
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)


### PR DESCRIPTION
This MR adds the help texts as a tooltip to the labels. This way users don't have to click on every button to see the help.
<img width="1127" height="848" alt="image" src="https://github.com/user-attachments/assets/0abfba48-613b-4e7b-a9e1-c7b24461df2b" />
