### PR TITLE
feat: enable default buttons if needed

### DIFF
--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -549,6 +549,7 @@ class RowWidget[T](QWidget):
         self.valueChanged.connect(self._set_internal_value)
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)
+        self._input_widget.valueChanged.connect(self.set_default_button_enable)
         self._input_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         self._default_button = QPushButton(self)
@@ -558,6 +559,7 @@ class RowWidget[T](QWidget):
         )
         self._default_button.clicked.connect(self.reset_default)
         self._default_button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
+        self._default_button.setEnabled(False)
 
         self._help_button = QPushButton(self)
         self._help_button.setFixedWidth(30)
@@ -582,6 +584,18 @@ class RowWidget[T](QWidget):
         """Open a dialog, showing help."""
         pos = self.mapToGlobal(self._help_button.pos())
         QToolTip.showText(pos, self.help)
+    
+    def set_default_button_enable(self, value: T):
+        """ Enables  default buttons if default value got changed
+
+        Args:
+            value: New value that was set in the input widget
+        """
+
+        if value != self._input_widget.default:
+            self._default_button.setEnabled(True)
+        else:
+            self._default_button.setEnabled(False)
 
     def setVisible(self, visible: bool, /) -> None:
         """Set the visibility of the row.

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -603,7 +603,7 @@ class RowWidget[T](QWidget):
         """Update Enable Flag of default buttons.
 
         If 'value' differs from the 'default' value, the setEnabled Flag gets set to True.
-        Otherwise the Flag gets set to False.
+        Otherwise the Flag gets set to False. As default the button is disabled.
         """
         self._default_button.setEnabled(self.value != self._input_widget.default)
 

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -210,6 +210,7 @@ class InputWidget[T](QWidget):
         self.setParent(parent)
         self.value = initial_value
         self.default = default
+        self.valueChanged.connect(self.set_value)
 
     @abstractmethod
     def set_widget_value(self, value: T) -> None:

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -550,7 +550,6 @@ class RowWidget[T](QWidget):
         self._label.setToolTip(help)
         self._label.setCursor(Qt.CursorShape.WhatsThisCursor)
         self.valueChanged.connect(self._set_internal_value)
-        self.valueChanged.connect(self.set_value)
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)
         self._input_widget.valueChanged.connect(self.set_default_button_enable)
@@ -621,8 +620,7 @@ class RowWidget[T](QWidget):
         Args:
             value: new value
         """
-        if self._input_widget.value != value:
-            self._input_widget.set_value(value)
+        self._input_widget.set_value(value)
 
     def _set_internal_value(self, value: T) -> None:
         """Update the internal value.

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -550,6 +550,7 @@ class RowWidget[T](QWidget):
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)
         self._input_widget.valueChanged.connect(self.set_default_button_enable)
+        self._input_widget.valueChanged.connect(self.set_default_button_enable)
         self._input_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         self._default_button = QPushButton(self)
@@ -559,6 +560,7 @@ class RowWidget[T](QWidget):
         )
         self._default_button.clicked.connect(self.reset_default)
         self._default_button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
+        self._default_button.setEnabled(False)
         self._default_button.setEnabled(False)
 
         self._help_button = QPushButton(self)
@@ -585,17 +587,13 @@ class RowWidget[T](QWidget):
         pos = self.mapToGlobal(self._help_button.pos())
         QToolTip.showText(pos, self.help)
     
-    def set_default_button_enable(self, value: T):
-        """ Enables  default buttons if default value got changed
+    def set_default_button_enable(self, value: T) -> None:
+        """Enables  default buttons if default value got changed.
 
         Args:
             value: New value that was set in the input widget
         """
-
-        if value != self._input_widget.default:
-            self._default_button.setEnabled(True)
-        else:
-            self._default_button.setEnabled(False)
+        self._default_button.setEnabled(value != self._input_widget.default)
 
     def setVisible(self, visible: bool, /) -> None:
         """Set the visibility of the row.

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -590,7 +590,7 @@ class RowWidget[T](QWidget):
     
     def set_default_button_enable(self) -> None:
         """Enables  default buttons if default value got changed."""
-        self._default_button.setEnabled(self._input_widget.value != self._input_widget.default)
+        self._default_button.setEnabled(self.value != self._input_widget.default)
 
     def setVisible(self, visible: bool, /) -> None:
         """Set the visibility of the row.

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -547,6 +547,7 @@ class RowWidget[T](QWidget):
         self.help = help
         self.description = description
         self._label = QLabel(description, self)
+        self._label.setToolTip(help)
         self.valueChanged.connect(self._set_internal_value)
         self.valueChanged.connect(self.set_value)
         self._input_widget = input_widget

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -548,6 +548,7 @@ class RowWidget[T](QWidget):
         self.description = description
         self._label = QLabel(description, self)
         self._label.setToolTip(help)
+        self._label.setCursor(Qt.WhatsThisCursor)
         self.valueChanged.connect(self._set_internal_value)
         self.valueChanged.connect(self.set_value)
         self._input_widget = input_widget

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -563,7 +563,7 @@ class RowWidget[T](QWidget):
         self.valueChanged.connect(self._set_internal_value)
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)
-        self._input_widget.valueChanged.connect(self.set_default_button_enable)
+        self._input_widget.valueChanged.connect(self.update_default_button_enable_flag)
         self._input_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         self._default_button = QPushButton(self)
@@ -573,7 +573,7 @@ class RowWidget[T](QWidget):
         )
         self._default_button.clicked.connect(self.reset_default)
         self._default_button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
-        self.set_default_button_enable()
+        self.update_default_button_enable_flag()
 
         self._help_button = QPushButton(self)
         self._help_button.setFixedWidth(30)
@@ -599,8 +599,12 @@ class RowWidget[T](QWidget):
         pos = self.mapToGlobal(self._help_button.pos())
         QToolTip.showText(pos, self.help)
     
-    def set_default_button_enable(self) -> None:
-        """Enables  default buttons if default value got changed."""
+    def update_default_button_enable_flag(self) -> None:
+        """Update Enable Flag of default buttons.
+
+        If 'value' differs from the 'default' value, the setEnabled Flag gets set to True.
+        Otherwise the Flag gets set to False.
+        """
         self._default_button.setEnabled(self.value != self._input_widget.default)
 
     def setVisible(self, visible: bool, /) -> None:

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -548,7 +548,7 @@ class RowWidget[T](QWidget):
         self.description = description
         self._label = QLabel(description, self)
         self._label.setToolTip(help)
-        self._label.setCursor(Qt.WhatsThisCursor)
+        self._label.setCursor(Qt.CursorShape.WhatsThisCursor)
         self.valueChanged.connect(self._set_internal_value)
         self.valueChanged.connect(self.set_value)
         self._input_widget = input_widget

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -728,6 +728,9 @@ class StrListWidget(QWidget):
         Args:
             values: new values
         """
+        if self._values == values:
+            return
+
         while self._layout.count() > 1:
             row = self._layout.itemAt(0)
             if row is not None:

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -547,6 +547,7 @@ class RowWidget[T](QWidget):
         self.description = description
         self._label = QLabel(description, self)
         self.valueChanged.connect(self._set_internal_value)
+        self.valueChanged.connect(self.set_value)
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)
         self._input_widget.valueChanged.connect(self.set_default_button_enable)
@@ -559,7 +560,7 @@ class RowWidget[T](QWidget):
         )
         self._default_button.clicked.connect(self.reset_default)
         self._default_button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
-        self._default_button.setEnabled(False)
+        self.set_default_button_enable()
 
         self._help_button = QPushButton(self)
         self._help_button.setFixedWidth(30)
@@ -585,13 +586,9 @@ class RowWidget[T](QWidget):
         pos = self.mapToGlobal(self._help_button.pos())
         QToolTip.showText(pos, self.help)
     
-    def set_default_button_enable(self, value: T) -> None:
-        """Enables  default buttons if default value got changed.
-
-        Args:
-            value: New value that was set in the input widget
-        """
-        self._default_button.setEnabled(value != self._input_widget.default)
+    def set_default_button_enable(self) -> None:
+        """Enables  default buttons if default value got changed."""
+        self._default_button.setEnabled(self._input_widget.value != self._input_widget.default)
 
     def setVisible(self, visible: bool, /) -> None:
         """Set the visibility of the row.
@@ -621,7 +618,8 @@ class RowWidget[T](QWidget):
         Args:
             value: new value
         """
-        self._input_widget.set_value(value)
+        if self._input_widget.value != value:
+            self._input_widget.set_value(value)
 
     def _set_internal_value(self, value: T) -> None:
         """Update the internal value.

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -550,7 +550,6 @@ class RowWidget[T](QWidget):
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)
         self._input_widget.valueChanged.connect(self.set_default_button_enable)
-        self._input_widget.valueChanged.connect(self.set_default_button_enable)
         self._input_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         self._default_button = QPushButton(self)
@@ -560,7 +559,6 @@ class RowWidget[T](QWidget):
         )
         self._default_button.clicked.connect(self.reset_default)
         self._default_button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
-        self._default_button.setEnabled(False)
         self._default_button.setEnabled(False)
 
         self._help_button = QPushButton(self)

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -922,8 +922,6 @@ class DeactivatableInputWidget[T](SplitInputWidget[T, bool, T | None]):
         """
         value = self.left_widget.value if enabled else None
         self.left_widget.setEnabled(enabled)
-        if value is not None:
-            self.left_widget.set_value(value)
         self.valueChanged.emit(value)
 
     @staticmethod

--- a/syng/player_libmpv.py
+++ b/syng/player_libmpv.py
@@ -96,6 +96,7 @@ class Player:
             osd_shadow_offset=10,
             osd_align_x="center",
             osd_align_y="top",
+            autofit_smaller="40%x40%",
         )
         self.next_up_overlay_id = self.mpv.allocate_overlay_id()
         self.next_up_y_pos = -120


### PR DESCRIPTION
The default buttons are enabled per default but clicking them doesn't change anything since the value is at default.
This gets changed. The default buttons are all disabled, now. They get enabled if the value in the widget changes to anything that isn't the default.

<img width="1118" height="843" alt="image" src="https://github.com/user-attachments/assets/83d02fd0-9e3e-4bfe-b1e1-e10d4084c7e8" />
