### PR TITLE
Fix  lower limit to mpv resizing

### DIFF
--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -549,6 +549,7 @@ class RowWidget[T](QWidget):
         self.valueChanged.connect(self._set_internal_value)
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)
+        self._input_widget.valueChanged.connect(self.set_default_button_enable)
         self._input_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         self._default_button = QPushButton(self)
@@ -558,6 +559,7 @@ class RowWidget[T](QWidget):
         )
         self._default_button.clicked.connect(self.reset_default)
         self._default_button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
+        self._default_button.setEnabled(False)
 
         self._help_button = QPushButton(self)
         self._help_button.setFixedWidth(30)
@@ -582,6 +584,18 @@ class RowWidget[T](QWidget):
         """Open a dialog, showing help."""
         pos = self.mapToGlobal(self._help_button.pos())
         QToolTip.showText(pos, self.help)
+    
+    def set_default_button_enable(self, value: T):
+        """ Enables  default buttons if default value got changed
+
+        Args:
+            value: New value that was set in the input widget
+        """
+
+        if value != self._input_widget.default:
+            self._default_button.setEnabled(True)
+        else:
+            self._default_button.setEnabled(False)
 
     def setVisible(self, visible: bool, /) -> None:
         """Set the visibility of the row.

--- a/syng/gui/row_widgets.py
+++ b/syng/gui/row_widgets.py
@@ -546,6 +546,7 @@ class RowWidget[T](QWidget):
         self.help = help
         self.description = description
         self._label = QLabel(description, self)
+        self._label.setToolTip(help)
         self.valueChanged.connect(self._set_internal_value)
         self._input_widget = input_widget
         self._input_widget.valueChanged.connect(self.valueChanged.emit)

--- a/syng/player_libmpv.py
+++ b/syng/player_libmpv.py
@@ -96,6 +96,7 @@ class Player:
             osd_shadow_offset=10,
             osd_align_x="center",
             osd_align_y="top",
+            autofit_smaller="40%x40%"
         )
         self.next_up_overlay_id = self.mpv.allocate_overlay_id()
         self.next_up_y_pos = -120


### PR DESCRIPTION
When using the window mode of mpv and cdg, it resizes to the video size and well, cdg is not high res so it looks something like this:
<img width="307" height="264" alt="image" src="https://github.com/user-attachments/assets/19b3a858-3ebf-42b9-99e1-55b150a8a456" />
fixing that issue is the [autofit-smaller option from mpv](https://mpv.io/manual/master/#options-autofit-smaller)
This way videos that are smaller then 40% of the screen get up scaled. Videos bigger then that are not getting down scaled.

<img width="1121" height="844" alt="image" src="https://github.com/user-attachments/assets/cf2f002f-32dc-4fc4-a4ef-a604f9b64088" />
