### PR TITLE
fix: add autofit-smaller option to mpv

### DIFF
--- a/syng/player_libmpv.py
+++ b/syng/player_libmpv.py
@@ -96,6 +96,7 @@ class Player:
             osd_shadow_offset=10,
             osd_align_x="center",
             osd_align_y="top",
+            autofit_smaller="40%x40%",
         )
         self.next_up_overlay_id = self.mpv.allocate_overlay_id()
         self.next_up_y_pos = -120


### PR DESCRIPTION
When using the window mode of mpv and cdg, it resizes to the video size and well, cdg is not high res so it looks something like this:
<img width="307" height="264" alt="image" src="https://github.com/user-attachments/assets/19b3a858-3ebf-42b9-99e1-55b150a8a456" />
fixing that issue is the [autofit-smaller option from mpv](https://mpv.io/manual/master/#options-autofit-smaller)
This way videos that are smaller then 40% of the screen get up scaled. Videos bigger then that are not getting down scaled.

<img width="1121" height="844" alt="image" src="https://github.com/user-attachments/assets/cf2f002f-32dc-4fc4-a4ef-a604f9b64088" />
